### PR TITLE
Remove outdated TODO comment in DeduplicatingResultSet

### DIFF
--- a/code/src/main/java/com/googlecode/cqengine/resultset/filter/DeduplicatingResultSet.java
+++ b/code/src/main/java/com/googlecode/cqengine/resultset/filter/DeduplicatingResultSet.java
@@ -37,7 +37,6 @@ import java.util.Iterator;
  */
 public class DeduplicatingResultSet<O, A> extends ResultSet<O> {
 
-    // TODO is this class unused?
 
     final ResultSet<O> wrappedResultSet;
     final Attribute<O, A> uniqueAttribute;


### PR DESCRIPTION
The TODO comment suggested that the class might be unused,
but it is referenced in Replace.java and DeduplicatingResultSetTest.

This PR removes the outdated TODO to avoid confusion.