### PR TITLE
Test: Upgraded Mockito from 2.27.0 to 5.23.0

### DIFF
--- a/code/pom.xml
+++ b/code/pom.xml
@@ -298,7 +298,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.27.0</version>
+            <version>5.23.0</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -342,14 +342,6 @@
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
             <version>3.16.1</version>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- ByteBuddy with Java 21 support - overrides version in EqualsVerifier -->
-        <dependency>
-            <groupId>net.bytebuddy</groupId>
-            <artifactId>byte-buddy</artifactId>
-            <version>1.14.11</version>
             <scope>test</scope>
         </dependency>
 

--- a/code/src/test/java/com/googlecode/cqengine/index/support/PartialIndexTest.java
+++ b/code/src/test/java/com/googlecode/cqengine/index/support/PartialIndexTest.java
@@ -186,7 +186,7 @@ public class PartialIndexTest {
     @SuppressWarnings("unchecked")
     static SortedKeyStatisticsAttributeIndex<Integer, Car> backingIndexSupportsQuery(Query<Car> querySupportedByBackingIndex) {
         SortedKeyStatisticsAttributeIndex attributeIndex = mock(SortedKeyStatisticsAttributeIndex.class);
-        when(attributeIndex.supportsQuery(Mockito.eq(querySupportedByBackingIndex), Mockito.<QueryOptions>any())).thenReturn(true);
+        when(attributeIndex.supportsQuery(Mockito.eq(querySupportedByBackingIndex), Mockito.any(QueryOptions.class))).thenReturn(true);
         return attributeIndex;
     }
 }

--- a/code/src/test/java/com/googlecode/cqengine/persistence/support/FilteredObjectStoreTest.java
+++ b/code/src/test/java/com/googlecode/cqengine/persistence/support/FilteredObjectStoreTest.java
@@ -63,7 +63,7 @@ public class FilteredObjectStoreTest {
     public void testIterator_Close() {
         CloseableIterator<Car> mockIterator = mock(CloseableIterator.class);
         ObjectStore<Car> mockObjectStore = mock(ObjectStore.class);
-        Mockito.when(mockObjectStore.iterator(Mockito.<QueryOptions>any())).thenReturn(mockIterator);
+        Mockito.when(mockObjectStore.iterator(Mockito.any(QueryOptions.class))).thenReturn(mockIterator);
 
         FilteredObjectStore<Car> filteredObjectStore = new FilteredObjectStore<Car>(
                 mockObjectStore,

--- a/code/src/test/java/com/googlecode/cqengine/persistence/support/ObjectSetTest.java
+++ b/code/src/test/java/com/googlecode/cqengine/persistence/support/ObjectSetTest.java
@@ -47,7 +47,7 @@ public class ObjectSetTest {
     public void testFromObjectStore_IteratorClose() throws Exception {
         ObjectStore<Car> objectStore = mock(ObjectStore.class);
         CloseableIterator<Car> closeableIterator = mock(CloseableIterator.class);
-        when(objectStore.iterator(Mockito.<QueryOptions>any())).thenReturn(closeableIterator);
+        when(objectStore.iterator(Mockito.any(QueryOptions.class))).thenReturn(closeableIterator);
 
         ObjectSet<Car> objectSet = ObjectSet.fromObjectStore(objectStore, noQueryOptions());
         CloseableIterator<Car> objectSetIterator = objectSet.iterator();
@@ -63,7 +63,7 @@ public class ObjectSetTest {
         when(closeableIterator.hasNext()).thenReturn(true);
         when(closeableIterator.next()).thenReturn(CarFactory.createCar(1));
 
-        when(objectStore.iterator(Mockito.<QueryOptions>any())).thenReturn(closeableIterator);
+        when(objectStore.iterator(Mockito.any(QueryOptions.class))).thenReturn(closeableIterator);
 
         ObjectSet<Car> objectSet = ObjectSet.fromObjectStore(objectStore, noQueryOptions());
         CloseableIterator<Car> objectSetIterator = objectSet.iterator();
@@ -78,7 +78,7 @@ public class ObjectSetTest {
     public void testFromObjectStore_ObjectSetClose() throws Exception {
         ObjectStore<Car> objectStore = mock(ObjectStore.class);
         CloseableIterator<Car> closeableIterator = mock(CloseableIterator.class);
-        when(objectStore.iterator(Mockito.<QueryOptions>any())).thenReturn(closeableIterator);
+        when(objectStore.iterator(Mockito.any(QueryOptions.class))).thenReturn(closeableIterator);
 
         ObjectSet<Car> objectSet = ObjectSet.fromObjectStore(objectStore, noQueryOptions());
         objectSet.iterator();
@@ -93,7 +93,7 @@ public class ObjectSetTest {
         ObjectStore<Car> objectStore = mock(ObjectStore.class);
         CloseableIterator<Car> closeableIterator = mock(CloseableIterator.class);
         when(closeableIterator.hasNext()).thenReturn(false);
-        when(objectStore.iterator(Mockito.<QueryOptions>any())).thenReturn(closeableIterator);
+        when(objectStore.iterator(Mockito.any(QueryOptions.class))).thenReturn(closeableIterator);
 
         ObjectSet<Car> objectSet = ObjectSet.fromObjectStore(objectStore, noQueryOptions());
         Assert.assertEquals(true, objectSet.isEmpty());
@@ -106,7 +106,7 @@ public class ObjectSetTest {
         ObjectStore<Car> objectStore = mock(ObjectStore.class);
         CloseableIterator<Car> closeableIterator = mock(CloseableIterator.class);
         when(closeableIterator.hasNext()).thenReturn(true);
-        when(objectStore.iterator(Mockito.<QueryOptions>any())).thenReturn(closeableIterator);
+        when(objectStore.iterator(Mockito.any(QueryOptions.class))).thenReturn(closeableIterator);
 
         ObjectSet<Car> objectSet = ObjectSet.fromObjectStore(objectStore, noQueryOptions());
         Assert.assertEquals(false, objectSet.isEmpty());


### PR DESCRIPTION
Fixes #20 

# Description
This PR upgrades the outdated Mockito package to the latest stable version at `5.23.0`, following this I have also removed the explicit dependency override for byte`byte-buddy`.
 
There were no compilation issues after migrating to the new version as all 10855 tests passed.

There were no deprecated verification modes used in any tests. 

As a bonus I have refactored the argument matchers used in test cases. Now, type check matchers strictly validate that the argument is a non-null instance of `QueryOptions` at runtime

# Key Changes
- In `pom.xml`, I have removed the `byte-buddy` because its now bundled, and updated Mockito from `2.27.0` to `5.23.0`
- In`PartialIndexTests.java`, `FilteredObjectStoreTest.java` and `ObjectSetTest.java`, I have refactored existing argument matchers `Mockito.<QueryOptions>.any()` to use `Mockito.any(QueryOptions.class)` for stricter validation of non-null instances of`QueryOptions` and readability

# Outputs
```
[INFO] Results:
[INFO]
[WARNING] Tests run: 10855, Failures: 0, Errors: 0, Skipped: 3
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```