### PR TITLE
Remove stale TODO comment from StandingQueryIndex

### DIFF
--- a/code/src/main/java/com/googlecode/cqengine/index/standingquery/StandingQueryIndex.java
+++ b/code/src/main/java/com/googlecode/cqengine/index/standingquery/StandingQueryIndex.java
@@ -101,7 +101,6 @@ public class StandingQueryIndex<O> implements Index<O>, OnHeapTypeIndex {
     @Override
     public ResultSet<O> retrieve(final Query<O> query, QueryOptions queryOptions) {
         if (!supportsQuery(query, queryOptions)) {
-            // TODO: check necessary?
             throw new IllegalArgumentException("Unsupported query: " + query);
         }
         return storedResultSet;


### PR DESCRIPTION

Removed the stale TODO comment in StandingQueryIndex.


The validation check was retained because StandingQueryIndex only supports the exact configured standing query. Removing the check could allow unsupported queries to return incorrect results.

## Changes
- Removed stale TODO comment
- Kept IllegalArgumentException for unsupported queries