### PR TITLE
fix: upgrade byte-buddy to 1.16.1 for Java 26 compatibility

### DIFF
--- a/code/pom.xml
+++ b/code/pom.xml
@@ -345,11 +345,11 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- ByteBuddy with Java 21 support - overrides version in EqualsVerifier -->
+        <!-- ByteBuddy with Java 26 support - overrides version in EqualsVerifier -->
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <version>1.14.11</version>
+            <version>1.16.1</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
## Problem
Tests were failing on Java 26 because byte-buddy 1.14.11 only supports 
up to Java 22.

## Failing tests (6)
- ReflectiveAttributeTest.testEqualsAndHashCode
- DiskPersistenceTest.testEqualsAndHashCode
- OffHeapPersistenceTest.testEqualsAndHashCode
- PartialIndexTest.testEqualsAndHashCode_PartialDiskIndex
- PartialIndexTest.testEqualsAndHashCode_PartialOffHeapIndex
- QueriesEqualsAndHashCodeTest.testQueryClass[StringMatchesRegex]

## Solution
- Upgraded byte-buddy from 1.14.11 to 1.16.1 (adds Java 26 support)
- Updated outdated comment in pom.xml

## Tested on
Java 26.0.1, macOS (Apple Silicon)