### PR TITLE
feat: automate Maven Central releases with GitHub Actions (#29)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: Release to Maven Central
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+          cache-dependency-path: 'code/pom.xml'
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Build, sign, and deploy to Maven Central
+        run: |
+          cd code
+          mvn clean deploy -P release-sign-artifacts \
+            -Dusername=${{ secrets.OSSRH_USERNAME }} \
+            -Dpassword=${{ secrets.OSSRH_PASSWORD }}
+        env:
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$TAG_VERSION" >> $GITHUB_OUTPUT
+          echo "Version: $TAG_VERSION"
+
+      - name: Create GitHub Release with auto-generated notes
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref }}
+          name: Release ${{ steps.version.outputs.version }}
+          body: |
+            ## Release Notes for v${{ steps.version.outputs.version }}
+            
+            **Artifacts deployed to Maven Central:**
+            
+            ```xml
+            <dependency>
+              <groupId>io.github.msaifasif</groupId>
+              <artifactId>cqengine</artifactId>
+              <version>${{ steps.version.outputs.version }}</version>
+            </dependency>
+            ```
+            
+            See [CHANGELOG](https://github.com/${{ github.repository }}/blob/${{ github.ref }}/CHANGELOG.md) for detailed changes.
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Issue
Closes #29

## What's Changed
- Added `.github/workflows/release.yml` for automated Maven Central releases
- Workflow triggers on version tags (v*)
- Includes GPG signing, OSSRH upload, and GitHub Release creation
- Uses `softprops/action-gh-release@v1` for auto-generated release notes (fixed deprecated `actions/create-release`)

## Setup Required
Maintainers need to configure 4 GitHub Secrets:
- `GPG_PRIVATE_KEY` — GPG private key (ASCII-armored)
- `GPG_PASSPHRASE` — GPG key passphrase
- `OSSRH_USERNAME` — Sonatype account email/ID
- `OSSRH_PASSWORD` — Sonatype auth token

## Testing
✅ Verified workflow YAML syntax  
✅ Verified `release-sign-artifacts` profile exists in pom.xml  
✅ Verified `nexus-staging-maven-plugin` configuration  
✅ Verified pom.xml has correct Maven Central coordinates  

## How to Use (Example only)
```bash
git tag v1.1.0
git push origin v1.1.0
```